### PR TITLE
feat: data shorthand

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,21 +21,18 @@ const Length = z.number().positive()
 
 //           v---------- 2. ADT Controller
 //           |            v--------- 1. ADT Builder
-export const Shape = Alge.data(`Shape`)
-  .record(`Rectangle`)
-  .schema({
+export const Shape = Alge.data(`Shape`, {
+  Rectangle: {
     width: Length,
     height: Length,
-  })
-  .record(`Circle`)
-  .schema({
+  },
+  Circle: {
     radius: Length,
-  })
-  .record(`Square`)
-  .schema({
+  },
+  Rectangle: {
     size: Length,
-  })
-  .done()
+  },
+})
 ```
 
 Now the Controller:

--- a/examples/GeometryDataSimple.ts
+++ b/examples/GeometryDataSimple.ts
@@ -11,7 +11,7 @@ export const Shape = Alge.data(`Shape`, {
   Circle: {
     radius: Length,
   },
-  Rectangle: {
+  Square: {
     size: Length,
   },
 })

--- a/examples/GeometryDataSimple.ts
+++ b/examples/GeometryDataSimple.ts
@@ -1,0 +1,22 @@
+import { Alge } from '../src/index.js'
+import { z } from 'zod'
+
+const Length = z.number().positive()
+
+export const Shape = Alge.data(`Shape`, {
+  Rectangle: {
+    width: Length,
+    height: Length,
+  },
+  Circle: {
+    radius: Length,
+  },
+  Rectangle: {
+    size: Length,
+  },
+})
+
+const circle = Shape.Circle.create({ radius: 10 })
+
+console.log({ circle })
+// { _tag: 'Circle', radius: 10 }

--- a/src/data/runtime.ts
+++ b/src/data/runtime.ts
@@ -6,6 +6,7 @@ import { record } from '../record/runtime.js'
 import { SomeRecord, SomeRecordController } from '../record/types/controller.js'
 import { SomeDecodeOrThrower, SomeDecoder, SomeEncoder, SomeRecordBuilder } from '../record/types/internal.js'
 import { Initial } from './types/Builder.js'
+import { DataController, SomeShortHandRecordDefs } from './types/Controller.js'
 import { SomeADT } from './types/internal.js'
 import { inspect } from 'util'
 import { SomeZodObject } from 'zod'
@@ -17,11 +18,16 @@ export type SomeAdtMethods = {
   to: Record<string, SomeEncoder>
 }
 
+//prettier-ignore
+export function data <Name extends string, ShortHandRecordDefs extends SomeShortHandRecordDefs>(name: Name, shortHandRecordDefs: ShortHandRecordDefs): DataController.createDataControllerFromShortHandRecords<Name, ShortHandRecordDefs>
 /**
  * Define an algebraic data type. There must be at least two members. If all members have a parse function then an ADT level parse function will automatically be derived.
  */
 // @ts-expect-error empty init tuple
-export const data = <Name extends string>(name: Name): Initial<{ name: Name }, []> => {
+//prettier-ignore
+export function data <Name extends string>(name: Name): Initial<{ name: Name }, []>
+//eslint-disable-next-line
+export function data<Name extends string>(name: Name, shortHandRecordDefinitions?: any) {
   // let currentRecord: null | SomeRecordDefinition = null
   // const records: SomeRecordDefinition[] = []
   let currentRecordBuilder: null | SomeRecordBuilder = null
@@ -138,6 +144,16 @@ export const data = <Name extends string>(name: Name): Initial<{ name: Name }, [
     },
   }
 
+  if (shortHandRecordDefinitions) {
+    let b = builder
+    //eslint-disable-next-line
+    for (const [name, schemaDefinition] of Object.entries(shortHandRecordDefinitions)) {
+      // @ts-expect-error todo
+      //eslint-disable-next-line
+      b = b.record(name).schema(schemaDefinition)
+    }
+    return b.done()
+  }
   // TODO
   // eslint-disable-next-line
   return builder as any

--- a/src/data/types/Builder.ts
+++ b/src/data/types/Builder.ts
@@ -8,6 +8,7 @@ import {
   CreateStoredRecord,
   CreateStoredRecordFromRecordController,
   ExtensionsBase,
+  SomeName,
   StoredRecords,
 } from '../../core/types.js'
 import { SomeRecordController } from '../../record/types/controller.js'
@@ -17,7 +18,7 @@ import { DataController } from './Controller.js'
 /**
  * The initial API for building an ADT.
  */
-export type Initial<ADT extends StoredADT, Vs extends StoredRecords> = RecordRequired<ADT, Vs>
+export type Initial<ADT extends StoredADT, Rs extends StoredRecords> = RecordRequired<ADT, Rs>
 
 /**
  * The builder API when it is in a state where a record is required.
@@ -25,9 +26,9 @@ export type Initial<ADT extends StoredADT, Vs extends StoredRecords> = RecordReq
  * @remarks This happens to be the initial state of the builder API.
  */
 // prettier-ignore
-export interface RecordRequired<ADT extends StoredADT, Vs extends StoredRecords> {
-  record<Name extends string>(name: Name): PostRecord<ADT, CreateStoredRecord<Name>, Vs>
-  record<DC extends SomeRecordController>(record: DC): PostRecord<ADT, CreateStoredRecordFromRecordController<DC>, Vs>
+export interface RecordRequired<ADT extends StoredADT, Rs extends StoredRecords> {
+  record<Name extends string>(name: Name): PostRecord<ADT, CreateStoredRecord<Name>, Rs>
+  record<DC extends SomeRecordController>(record: DC): PostRecord<ADT, CreateStoredRecordFromRecordController<DC>, Rs>
 }
 
 /**
@@ -36,10 +37,10 @@ export interface RecordRequired<ADT extends StoredADT, Vs extends StoredRecords>
  * @remarks This happens to be the initial state of the builder API.
  */
 // prettier-ignore
-export interface PostRecord<ADT extends StoredADT, V extends StoredRecord, Vs extends StoredRecords>
-       extends RecordRequired<ADT, [V, ...Vs]>,
-               Done<ADT, V, Vs> {
-  schema<Schema extends SomeSchemaDef>(schema: Schema): PostSchema<ADT, StoredRecord.AddSchemaDefinition<Schema, V>, Vs>
+export interface PostRecord<ADT extends StoredADT, R extends StoredRecord, Vs extends StoredRecords>
+       extends RecordRequired<ADT, [R, ...Vs]>,
+               Done<ADT, R, Vs> {
+  schema<Schema extends SomeSchemaDef>(schema: Schema): PostSchema<ADT, StoredRecord.AddSchemaDefinition<Schema, R>, Vs>
 }
 
 /**
@@ -47,19 +48,23 @@ export interface PostRecord<ADT extends StoredADT, V extends StoredRecord, Vs ex
  * At this point the ADT can be marked as done.
  */
 // prettier-ignore
-export interface PostSchema<ADT extends StoredADT, V extends StoredRecord, Vs extends StoredRecords>
-       extends RecordRequired<ADT, [V, ...Vs]>,
-               Done<ADT, V, Vs> {
-  codec<Name extends string>(name: Name, implementation: CodecImplementation<V>): PostSchema<ADT, StoredRecord.AddCodec<Name, V>, Vs>
-  extend<Extensions extends ExtensionsBase>(extensions: Extensions): PostSchema<ADT, StoredRecord.AddExtensions<Extensions, V>, Vs>
+export interface PostSchema<ADT extends StoredADT, R extends StoredRecord, Rs extends StoredRecords>
+       extends RecordRequired<ADT, [R, ...Rs]>,
+               Done<ADT, R, Rs> {
+  codec<Name extends string>(name: Name, implementation: CodecImplementation<R>): PostSchema<ADT, StoredRecord.AddCodec<Name, R>, Rs>
+  extend<Extensions extends ExtensionsBase>(extensions: Extensions): PostSchema<ADT, StoredRecord.AddExtensions<Extensions, R>, Rs>
 }
 
-export interface Done<ADT extends StoredADT, V extends StoredRecord, Vs extends StoredRecords> {
-  done(): DataController<ADT, [V, ...Vs]>
+export interface Done<ADT extends StoredADT, R extends StoredRecord, Rs extends StoredRecords> {
+  done(): DataController<ADT, [R, ...Rs]>
 }
 
 // Helpers
 
-export type StoredADT<Name extends string = string> = {
+export type StoredADT<Name extends SomeName = SomeName> = {
   name: Name
+}
+
+export namespace StoredADT {
+  export type Create<Name extends SomeName = SomeName> = StoredADT<Name>
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -38,7 +38,7 @@ export type Rest<x extends unknown[]> = x extends [infer _first, ...infer rest] 
 
 export type IndexKeys<A extends readonly unknown[]> = Exclude<keyof A, keyof []>
 
-export type AsString<x> = x extends string ? x : never
+export type OnlyStrings<x> = x extends string ? x : never
 
 export type OmitRequired<T> = {
   [K in keyof T as undefined extends T[K] ? never : K]: T[K]

--- a/tests/data/constructor/shorthand.spec.ts
+++ b/tests/data/constructor/shorthand.spec.ts
@@ -1,0 +1,22 @@
+import { Alge } from '../../../src/index.js'
+import { expectType } from 'tsd'
+import { z } from 'zod'
+
+it(`supports shorthand`, () => {
+  const AB = Alge.data(`AB`, {
+    A: { a: z.string() },
+    B: { b: z.string() },
+  })
+  const AB2 = Alge.data(`AB`)
+    .record(`B`)
+    .schema({ b: z.string() })
+    .record(`A`)
+    .schema({ a: z.string() })
+    .done()
+
+  expectType<typeof AB2>(AB)
+  expectType<typeof AB>(AB2)
+
+  expect(AB.A.create({ a: `` })).toMatchObject({ _tag: `A`, a: `` })
+  expect(AB.B.create({ b: `` })).toMatchObject({ _tag: `B`, b: `` })
+})


### PR DESCRIPTION
closes #84

Now this is possible:

```ts
const Shape = Alge.data(`Shape`, {
  Rectangle: {
    width: Length,
    height: Length,
  },
  Circle: {
    radius: Length,
  },
  Rectangle: {
    size: Length,
  },
})
```

Whereas before it had to be:

```ts
const Shape = Alge.data(`Shape`)
  .record(`Rectangle`)
  .schema({
    width: Length,
    height: Length,
  })
  .record(`Circle`)
  .schema({
    radius: Length,
  })
  .record(`Square`)
  .schema({
    size: Length,
  })
  .done()
```